### PR TITLE
Feat/ds 158/unstake after start before end

### DIFF
--- a/libs/ew-crowdfunding/smart-contracts/test/index.ts
+++ b/libs/ew-crowdfunding/smart-contracts/test/index.ts
@@ -285,5 +285,24 @@ describe("Staking", () => {
     await expect(
       asPatron.unstakeAll()
     ).to.be.revertedWith('Withdraws not allowed');
-  })
+  });
+
+  it('Can partially withdraw funds after end date', async () => {
+    //Moving to endDate
+    await timeTravel(provider, end);
+
+    let tx;
+    expect(tx = await asPatron2.withdraw(oneEWT)).changeEtherBalance(asPatron2, (oneEWT.mul(-1)));
+    const { blockNumber } = await tx.wait();
+    const { timestamp } = await provider.getBlock(blockNumber);
+    await expect(tx).to.emit(stakingContract, 'Withdrawn').withArgs(patron2.address, oneEWT.mul(1), timestamp);
+  });
+
+  it('Can withdraw all funds after end date', async () => {
+    let tx;
+    expect(tx = await asPatron2.unstakeAll()).changeEtherBalance(asPatron2, (oneEWT.mul(-1)));
+    const { blockNumber } = await tx.wait();
+    const { timestamp } = await provider.getBlock(blockNumber);
+    await expect(tx).to.emit(stakingContract, 'Withdrawn').withArgs(patron2.address, oneEWT.mul(1), timestamp);
+  });
 })


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description | This PR prevents full or partial withdraws for verified user after startTime and before endTime |
| Feature | Unstake |
| Scenario | Verified user wants to unstake his EWT |
| Jira issue  | https://energyweb.atlassian.net/browse/DS-158  |

#### Story summary

Given user has staked EWT

When staking contract has reached the start date

Then user should be not able to unstake funds until the end date

#### Type of request
- [x] New feature (non-breaking change which adds functionality)

